### PR TITLE
feat: added hoc for margins

### DIFF
--- a/src/components/BaseInput.tsx
+++ b/src/components/BaseInput.tsx
@@ -1,11 +1,9 @@
 import { InputHTMLAttributes } from "react";
 import styled from "styled-components";
 import { GRAY, DARK, OPACITY10, OPACITY1 } from "../utils/colors";
+import { withLayoutStyles } from "./LayoutStyles";
 
-const InputArea = styled.input<{ mt?: number; ml?: number }>`
-  margin-top: ${(props) => props.mt}px;
-  margin-left: ${(props) => props.ml}px;
-
+const InputArea = styled.input`
   font-size: 0.875rem;
   padding: 8px 12px;
   background-color: ${GRAY}${OPACITY10};
@@ -27,6 +25,8 @@ interface BaseInputType extends InputHTMLAttributes<HTMLInputElement> {
   ml?: number;
 }
 
-export const BaseInput: React.FC<BaseInputType> = ({ ...rest }) => {
+const BaseInputToTransform: React.FC<BaseInputType> = ({ ...rest }) => {
   return <InputArea {...rest} />;
 };
+
+export const BaseInput = withLayoutStyles(BaseInputToTransform);

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -3,9 +3,9 @@ import { GRAY, WHITE } from "../utils/colors";
 import { FlexBox } from "./FlexBox";
 import cover from "../assets/cover.png";
 import { Dots } from "./Dots";
+import { withLayoutStyles } from "./LayoutStyles";
 
-const CardWrapper = styled.section<{ mt?: number }>`
-  margin-top: ${(props) => props.mt}px;
+const CardWrapper = styled.section`
   background-color: ${WHITE};
   border-radius: 20px;
   padding: 32px;
@@ -35,13 +35,9 @@ const ButtonWrapper = styled.div`
   cursor: pointer;
 `;
 
-type CardProps = {
-  mt?: number;
-};
-
-export const Card: React.FC<CardProps> = ({ mt }) => {
+const CardToTransform: React.FC = withLayoutStyles(() => {
   return (
-    <CardWrapper mt={mt}>
+    <CardWrapper>
       <FlexBox>
         <img width={48} src={cover} alt="4 Hour Workweek Book cover" />
         <FlexBox direction="column" ml={16}>
@@ -60,4 +56,6 @@ export const Card: React.FC<CardProps> = ({ mt }) => {
       </TextWrapper>
     </CardWrapper>
   );
-};
+});
+
+export const Card = withLayoutStyles(CardToTransform);

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -35,7 +35,7 @@ const ButtonWrapper = styled.div`
   cursor: pointer;
 `;
 
-const CardToTransform: React.FC = withLayoutStyles(() => {
+export const CardToTransform: React.FC = () => {
   return (
     <CardWrapper>
       <FlexBox>
@@ -56,6 +56,6 @@ const CardToTransform: React.FC = withLayoutStyles(() => {
       </TextWrapper>
     </CardWrapper>
   );
-});
+};
 
 export const Card = withLayoutStyles(CardToTransform);

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -2,9 +2,9 @@ import styled from "styled-components";
 import { GRAY, WHITE } from "../utils/colors";
 import { FlexBox } from "./FlexBox";
 import { Dots } from "./Dots";
+import { withLayoutStyles } from "./LayoutStyles";
 
-const CommentWrapper = styled.section<{ mt?: number }>`
-  margin-top: ${(props) => props.mt}px;
+const CommentWrapper = styled.section`
   background-color: ${WHITE};
   border-radius: 20px;
   padding: 32px;
@@ -31,9 +31,9 @@ type CommentProps = {
   mt?: number;
 };
 
-export const Comment: React.FC<CommentProps> = ({ mt }) => {
+export const CommentToTransform: React.FC<CommentProps> = () => {
   return (
-    <CommentWrapper mt={mt}>
+    <CommentWrapper>
       <FlexBox jc="space-between" ai="center">
         <CommentDate>2020/08/02</CommentDate>
         <ButtonWrapper>
@@ -49,3 +49,5 @@ export const Comment: React.FC<CommentProps> = ({ mt }) => {
     </CommentWrapper>
   );
 };
+
+export const Comment = withLayoutStyles(CommentToTransform);

--- a/src/components/Heatmap.tsx
+++ b/src/components/Heatmap.tsx
@@ -1,7 +1,7 @@
 import CalendarHeatmap from "react-calendar-heatmap";
 import "react-calendar-heatmap/dist/styles.css";
 import ReactTooltip from "react-tooltip";
-import styled from "styled-components";
+import { withLayoutStyles } from "./LayoutStyles";
 
 type HeatmapProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,12 +24,8 @@ function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-const Container = styled.div`
-  margin-top: 32px;
-`;
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Heatmap: React.FC<HeatmapProps> = ({ data }) => {
+const HeatmapToTransform: React.FC<HeatmapProps> = ({ data }) => {
   const randomValues = getRange(200).map((index) => {
     return {
       date: shiftDate(today, -index),
@@ -37,7 +33,7 @@ export const Heatmap: React.FC<HeatmapProps> = ({ data }) => {
     };
   });
   return (
-    <Container>
+    <>
       <CalendarHeatmap
         startDate={shiftDate(today, -90)}
         endDate={today}
@@ -60,6 +56,8 @@ export const Heatmap: React.FC<HeatmapProps> = ({ data }) => {
         showMonthLabels={false}
       />
       <ReactTooltip />
-    </Container>
+    </>
   );
 };
+
+export const Heatmap = withLayoutStyles(HeatmapToTransform);

--- a/src/components/LayoutStyles.tsx
+++ b/src/components/LayoutStyles.tsx
@@ -12,6 +12,7 @@ export function withLayoutStyles<P>(
 ): StyledComponent<React.FC<P>, object, P & LayoutStylesProps, never> {
   const ComponentWithAdded = styled(Component)<LayoutStylesProps & P>`
     margin-top: ${(props) => props.mt}px;
+    margin-left: ${(props) => props.ml}px;
   `;
 
   return ComponentWithAdded;

--- a/src/components/LayoutStyles.tsx
+++ b/src/components/LayoutStyles.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/ban-types */
+import styled, { StyledComponent } from "styled-components";
+
+type LayoutStylesProps = {
+  mt?: number;
+  ml?: number;
+};
+
+export function withLayoutStyles<P>(
+  Component: React.FC<P>
+): StyledComponent<React.FC<P>, object, P & LayoutStylesProps, never> {
+  const ComponentWithAdded = styled(Component)<LayoutStylesProps & P>`
+    margin-top: ${(props) => props.mt}px;
+  `;
+
+  return ComponentWithAdded;
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,15 +1,15 @@
 import styled from "styled-components";
 import srLogo from "../assets/srLogo.png";
 import { FlexBox } from "./FlexBox";
+import { withLayoutStyles } from "./LayoutStyles";
 
 const SiteHeader = styled.h1`
   font-family: "Abhaya Libre", serif;
   font-size: 2rem;
   font-weight: 800;
-  margin-left: 12px;
 `;
 
-export const Logo: React.FC = () => {
+const LogoToTransform: React.FC = () => {
   return (
     <FlexBox ai="center">
       <img src={srLogo} alt="logo" />
@@ -17,3 +17,5 @@ export const Logo: React.FC = () => {
     </FlexBox>
   );
 };
+
+export const Logo = withLayoutStyles(LogoToTransform);

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ export const Navbar: React.FC = () => {
     <NavbarWrapper>
       <NavbarContainer>
         <NavbarInner>
-          <Logo />
+          <Logo ml={12} />
           <BaseInput placeholder="Notes & Books" />
         </NavbarInner>
       </NavbarContainer>

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-
 import { GRAY } from "../utils/colors";
+import { withLayoutStyles } from "./LayoutStyles";
 
 type VariantType = "large" | "medium" | "small";
 
@@ -11,8 +11,7 @@ type TitleType = {
   mt?: number;
 };
 
-const TitleWrapper = styled.div<{ mt?: number }>`
-  margin-top: ${(props) => props.mt}px;
+const TitleWrapper = styled.div`
   font-family: "'Abhaya Libre', serif";
 `;
 
@@ -48,11 +47,10 @@ const TitleSmall = styled.h4`
   color: ${GRAY};
 `;
 
-export const Title: React.FC<TitleType> = ({
+const TitleToTransform: React.FC<TitleType> = ({
   variant = "small",
   title,
   subtitle,
-  mt,
 }) => {
   function getTitleAndSubtitleByType(
     styleType: VariantType,
@@ -80,8 +78,10 @@ export const Title: React.FC<TitleType> = ({
   }
 
   return (
-    <TitleWrapper mt={mt}>
+    <TitleWrapper>
       {getTitleAndSubtitleByType(variant, title, subtitle)}
     </TitleWrapper>
   );
 };
+
+export const Title = withLayoutStyles(TitleToTransform);


### PR DESCRIPTION
As it was mentioned in #11  
The best what I could possibly do! Check the commits to see how to use it

# Features
* Adding `mt`, `ml` props to the wrapped component
* Possibility to add other directions in one place if needed

# To be aware of
Wrap the component after it was declared, for some reason it doesn't work if you wrap it when you're declaring it